### PR TITLE
feat: Add pretty_exceptions_suppress

### DIFF
--- a/docs/tutorial/exceptions.md
+++ b/docs/tutorial/exceptions.md
@@ -202,6 +202,18 @@ $ python main.py
 
 </div>
 
+## Suppress Frames from Pretty Exceptions
+
+By default, typer will **omit** all the parts of the traceback that come from the internal parts in Typer and Click, but you can exclude frames from additional
+frameworks using `pretty_exceptions_suppress`, which should be a list of modules or str paths.
+
+```Python
+import typer
+import sqlalchemy
+
+app = typer.Typer(pretty_exceptions_suppress=[sqlalchemy])
+```
+
 ## Disable Pretty Exceptions
 
 You can also entirely disable pretty exceptions with the parameter `pretty_exceptions_enable=False`:

--- a/typer/main.py
+++ b/typer/main.py
@@ -7,8 +7,8 @@ from enum import Enum
 from functools import update_wrapper
 from pathlib import Path
 from traceback import FrameSummary, StackSummary
-from types import TracebackType
-from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Type, Union
+from types import ModuleType, TracebackType
+from typing import Any, Callable, Dict, Iterable, List, Optional, Sequence, Tuple, Type, Union
 from uuid import UUID
 
 import click
@@ -67,6 +67,9 @@ def except_hook(
     typer_path = os.path.dirname(__file__)
     click_path = os.path.dirname(click.__file__)
     supress_internal_dir_names = [typer_path, click_path]
+    suppress = supress_internal_dir_names + list(
+        exception_config.pretty_exceptions_suppress
+    )
     exc = exc_value
     if rich:
         rich_tb = Traceback.from_exception(
@@ -74,7 +77,7 @@ def except_hook(
             exc,
             exc.__traceback__,
             show_locals=exception_config.pretty_exceptions_show_locals,
-            suppress=supress_internal_dir_names,
+            suppress=suppress,
         )
         console_stderr.print(rich_tb)
         return
@@ -137,6 +140,7 @@ class Typer:
         pretty_exceptions_enable: bool = True,
         pretty_exceptions_show_locals: bool = True,
         pretty_exceptions_short: bool = True,
+        pretty_exceptions_suppress: Iterable[Union[str, ModuleType]] = ()
     ):
         self._add_completion = add_completion
         self.rich_markup_mode: MarkupMode = rich_markup_mode
@@ -144,6 +148,7 @@ class Typer:
         self.pretty_exceptions_enable = pretty_exceptions_enable
         self.pretty_exceptions_show_locals = pretty_exceptions_show_locals
         self.pretty_exceptions_short = pretty_exceptions_short
+        self.pretty_exceptions_suppress = pretty_exceptions_suppress
         self.info = TyperInfo(
             name=name,
             cls=cls,
@@ -321,6 +326,7 @@ class Typer:
                     pretty_exceptions_enable=self.pretty_exceptions_enable,
                     pretty_exceptions_show_locals=self.pretty_exceptions_show_locals,
                     pretty_exceptions_short=self.pretty_exceptions_short,
+                    pretty_exceptions_suppress=self.pretty_exceptions_suppress,
                 ),
             )
             raise e

--- a/typer/main.py
+++ b/typer/main.py
@@ -8,7 +8,18 @@ from functools import update_wrapper
 from pathlib import Path
 from traceback import FrameSummary, StackSummary
 from types import ModuleType, TracebackType
-from typing import Any, Callable, Dict, Iterable, List, Optional, Sequence, Tuple, Type, Union
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Iterable,
+    List,
+    Optional,
+    Sequence,
+    Tuple,
+    Type,
+    Union,
+)
 from uuid import UUID
 
 import click
@@ -140,7 +151,7 @@ class Typer:
         pretty_exceptions_enable: bool = True,
         pretty_exceptions_show_locals: bool = True,
         pretty_exceptions_short: bool = True,
-        pretty_exceptions_suppress: Iterable[Union[str, ModuleType]] = ()
+        pretty_exceptions_suppress: Iterable[Union[str, ModuleType]] = (),
     ):
         self._add_completion = add_completion
         self.rich_markup_mode: MarkupMode = rich_markup_mode

--- a/typer/models.py
+++ b/typer/models.py
@@ -515,7 +515,7 @@ class DeveloperExceptionConfig:
         pretty_exceptions_enable: bool = True,
         pretty_exceptions_show_locals: bool = True,
         pretty_exceptions_short: bool = True,
-        pretty_exceptions_suppress: Iterable[Union[str, ModuleType]] = ()
+        pretty_exceptions_suppress: Iterable[Union[str, ModuleType]] = (),
     ) -> None:
         self.pretty_exceptions_enable = pretty_exceptions_enable
         self.pretty_exceptions_show_locals = pretty_exceptions_show_locals

--- a/typer/models.py
+++ b/typer/models.py
@@ -1,10 +1,12 @@
 import inspect
 import io
+from types import ModuleType
 from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
     Dict,
+    Iterable,
     List,
     Optional,
     Sequence,
@@ -513,7 +515,9 @@ class DeveloperExceptionConfig:
         pretty_exceptions_enable: bool = True,
         pretty_exceptions_show_locals: bool = True,
         pretty_exceptions_short: bool = True,
+        pretty_exceptions_suppress: Iterable[Union[str, ModuleType]] = ()
     ) -> None:
         self.pretty_exceptions_enable = pretty_exceptions_enable
         self.pretty_exceptions_show_locals = pretty_exceptions_show_locals
         self.pretty_exceptions_short = pretty_exceptions_short
+        self.pretty_exceptions_suppress = pretty_exceptions_suppress


### PR DESCRIPTION
This pull request extends the `pretty_exceptions` feature by adding `pretty_exceptions_suppress`. It adds the ability to exclude frames from additional frameworks using the `pretty_exceptions_suppress` parameter, which should be a list of modules or string paths. 